### PR TITLE
feat: treat pytest warnings as errors to catch deprecations early

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -306,12 +306,19 @@ python_functions = ["test_*"]
 addopts = [
     "--strict-markers",
     "--strict-config",
+    "-W error",  # STRICT: Treat warnings as errors (catch deprecations early)
     "--tb=short",
     "--cov=.",
     "--cov-report=term-missing:skip-covered",
     "--cov-report=html",
     "--cov-report=xml",
     "--cov-fail-under=80",  # STRICT: Require 80% coverage
+]
+filterwarnings = [
+    "error",  # Treat all warnings as errors by default
+    # Uncomment to selectively ignore specific third-party warnings if needed:
+    # "ignore::DeprecationWarning:some_noisy_library",
+    # "ignore::UserWarning:another_library",
 ]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",


### PR DESCRIPTION
- Add -W error flag to pytest to fail tests on any warnings
- Add filterwarnings section with examples for selective ignoring
- Catches deprecation warnings, future warnings, and user warnings
- Prevents LLMs from using deprecated APIs that go unnoticed
- Aligns with ultra-strict philosophy (strict-markers, strict-config, coverage)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced testing configuration to improve code quality and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->